### PR TITLE
Add Clippy to CI and clean up the workflow yml a bit

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -1,6 +1,13 @@
 name: gccrs-testing-test
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+env:
+  RUSTFLAGS: '-Dwarnings'
 
 jobs:
   coding-style:
@@ -9,9 +16,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Check the coding style
-      run: |
-          cd testsuite-adaptor
-          cargo fmt -- --check
+      run: cargo fmt -- --check
+      working-directory: testsuite-adaptor
 
   check:
     runs-on: ubuntu-latest
@@ -19,13 +25,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Build testsuite-adaptor
-      run: |
-          cd testsuite-adaptor
-          cargo check
+    - name: Check testsuite-adaptor
+      run: cargo check
+      working-directory: testsuite-adaptor
+    - name: Run Clippy
+      run: cargo clippy --all -- -Wclippy::pedantic
+      working-directory: testsuite-adaptor
 
   # Generate an entire testsuite to make sure it completes properly
   run:
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     needs: check
 

--- a/testsuite-adaptor/src/passes.rs
+++ b/testsuite-adaptor/src/passes.rs
@@ -62,7 +62,7 @@ impl Display for TestCase {
         writeln!(f, "    exit_code: {}", self.exit_code)?;
         writeln!(f, "    args:")?;
 
-        for arg in self.args.iter() {
+        for arg in &self.args {
             writeln!(f, "      - \"{}\"", arg)?;
         }
 


### PR DESCRIPTION
See commit messages for details. 

Using `-Wclippy::pedantic` might be debatable and a bit too pedantic. So that's for you to decide. But a project (where I can scream at the maintainers in person at least once a week) that doesn't use Clippy cannot exist :paperclip: :crab: 

No idea if this workflow works, but I hope it does, let's find out :rocket: 