### PR TITLE
Add libcore pass

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -50,3 +50,4 @@ jobs:
           gccrs-rustc-success-no-core \
           gccrs-rustc-success-no-std \
           blake3 \
+          libcore-1.49 \

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,14 @@
 use std::convert::From;
 
 #[derive(Debug, thiserror::Error)]
+pub enum MiscKind {
+    /// Error when checking out a specific tag or commit in a particular repo
+    /// used when generating test suites
+    #[error("git error: `git {arg_string}`")]
+    Git { arg_string: String },
+}
+
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("{0}")]
     Io(std::io::Error),
@@ -12,6 +20,8 @@ pub enum Error {
     PathPrefix(std::path::StripPrefixError),
     #[error("{0}")]
     WalkDir(walkdir::Error),
+    #[error("{0}")]
+    Misc(MiscKind),
 }
 
 impl From<std::io::Error> for Error {

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,7 @@ fn pass_dispatch(pass: &PassKind) -> Vec<Box<dyn Pass>> {
             .into_iter()
             .map(|blake_variant| Box::new(blake_variant) as Box<dyn Pass>)
             .collect(),
+        PassKind::LibCore149 => vec![Box::new(passes::LibCore::V149)],
     }
 }
 

--- a/src/passes.rs
+++ b/src/passes.rs
@@ -1,11 +1,13 @@
 mod blake3;
 mod gccrs_parsing;
 mod gccrs_rustc_successes;
+mod libcore;
 mod rustc_dejagnu;
 
 pub use blake3::Blake3;
 pub use gccrs_parsing::GccrsParsing;
 pub use gccrs_rustc_successes::GccrsRustcSuccesses;
+pub use libcore::LibCore;
 pub use rustc_dejagnu::RustcDejagnu;
 
 use std::{
@@ -148,6 +150,8 @@ pub enum PassKind {
     GccrsRustcSucessNoCore,
     /// Compile the reference implementation of the Blake3 cryptographic algorithm
     Blake3,
+    /// Compile libcore from rust 1.49.0
+    LibCore149,
 }
 
 #[derive(Debug)]
@@ -170,6 +174,7 @@ impl FromStr for PassKind {
             "gccrs-rustc-success-no-std" => Ok(PassKind::GccrsRustcSucessNoStd),
             "gccrs-rustc-success-no-core" => Ok(PassKind::GccrsRustcSucessNoCore),
             "blake3" => Ok(PassKind::Blake3),
+            "libcore-1.49" => Ok(PassKind::LibCore149),
             s => Err(InvalidPassKind(s.to_string())),
         }
     }
@@ -184,6 +189,7 @@ impl Display for PassKind {
             PassKind::GccrsRustcSucessNoStd => "gccrs-rustc-success-no-std",
             PassKind::GccrsRustcSucessNoCore => "gccrs-rustc-success-no-core",
             PassKind::Blake3 => "blake3",
+            PassKind::LibCore149 => "libcore-1.49",
         };
 
         write!(f, "{}", s)

--- a/src/passes/libcore.rs
+++ b/src/passes/libcore.rs
@@ -1,0 +1,47 @@
+use std::path::{Path, PathBuf};
+
+use crate::args::Args;
+use crate::copy_rs_files;
+use crate::error::Error;
+use crate::passes::{Pass, TestCase};
+
+pub enum LibCore {
+    // libcore from rustc 1.49.0
+    V149,
+}
+
+impl LibCore {
+    fn as_str(&self) -> &str {
+        match self {
+            LibCore::V149 => "1.49",
+        }
+    }
+}
+
+impl Pass for LibCore {
+    fn fetch(&self, args: &Args) -> Result<Vec<PathBuf>, Error> {
+        let rust_path = &args.rust_path;
+        let core_path = rust_path.join("library").join("core");
+
+        // TODO: How do we ensure the rustc submodule contains 1.49.0 libcore?
+        // Should we keep it as a template? Should we do some `git checkout` horrors
+        // here?
+
+        copy_rs_files(&core_path, &args.output_dir, rust_path)?;
+
+        // We only want to compile a single file, and the others as modules
+        Ok(vec![args
+            .output_dir
+            .join(core_path)
+            .join("src")
+            .join("lib.rs")])
+    }
+
+    fn adapt(&self, args: &Args, file: &Path) -> Result<TestCase, Error> {
+        Ok(TestCase::new()
+            .with_name(format!("Compiling libcore {}", self.as_str()))
+            .with_binary(args.gccrs.display())
+            .with_arg(file.display())
+            .with_exit_code(0))
+    }
+}


### PR DESCRIPTION
This adds a first basic pass to compile libcore 1.49.0 + the ability to extend it to other versions down the line. We currently perform no transformations on the library, but this is something we might need to think about