### PR TITLE
Add default timeout and fix timeout in `gccrs_successes` pass

### DIFF
--- a/src/passes.rs
+++ b/src/passes.rs
@@ -40,7 +40,8 @@ impl TestCase {
             name: String::new(),
             binary: String::new(),
             exit_code: 0u8,
-            timeout: i32::MAX,
+            // FIXME: Use duration here (#10)
+            timeout: 15 * 60, // default timeout is 15 minutes
             stderr: String::new(),
             stdout: String::new(),
             args: vec![],

--- a/src/passes/gccrs_rustc_successes.rs
+++ b/src/passes/gccrs_rustc_successes.rs
@@ -96,7 +96,8 @@ impl Pass for GccrsRustcSuccesses {
             .with_name(format!("Compile {} success `{}`", self, file.display()))
             .with_binary(args.gccrs.display())
             .with_exit_code(0)
-            .with_timeout(5)
+            // FIXME: Use proper duration here (#10)
+            .with_timeout(5 * 60) // ftf's timeout is in seconds, so 5 minutes
             .with_arg(file.display());
 
         Ok(test_case)


### PR DESCRIPTION
Closes #17
Closes #18