### PR TITLE
ci: Fix OOM issues when running through testsuite

### DIFF
--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -37,7 +37,7 @@ jobs:
 
           # FIXME: Hack: This allows us to access `rust1` directly.
           # Figure out a better way to do it
-          PATH=/usr/local/libexec/gcc/x86_64-pc-linux-gnu/12.0.1/:$PATH ftf -f ${{ matrix.testsuite }}.yaml -j$(nproc) --result-fmt "{ \"tests\": %t, \"passes\": %p, \"failures\": %f }" | tee log;
+          PATH=/usr/local/libexec/gcc/x86_64-pc-linux-gnu/12.0.1/:$PATH ftf -f ${{ matrix.testsuite }}.yaml -j 1 --result-fmt "{ \"tests\": %t, \"passes\": %p, \"failures\": %f }" | tee log;
 
           tail -n 1 log >> ${{ matrix.testsuite }}.json
           echo "}" >> ${{ matrix.testsuite }}.json


### PR DESCRIPTION
On the 15th of june during the scheduled run, the action exited with
exit-code 137 when running the `ftf` command which indicates runner starvation.

Let's run it single-threaded for now and see if the situation improves.