### PR TITLE
libcore: Use compilation steps and add libcore-1.29 as testsuite

### DIFF
--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -10,7 +10,7 @@ jobs:
     container: philberty/gccrs:latest
     strategy:
       matrix:
-        testsuite: [rustc-dejagnu, gccrs-parsing, gccrs-rustc-success, gccrs-rustc-success-no-std, gccrs-rustc-success-no-core, blake3, libcore-1.49]
+        testsuite: [rustc-dejagnu, gccrs-parsing, gccrs-rustc-success, gccrs-rustc-success-no-std, gccrs-rustc-success-no-core, blake3, libcore]
     steps:
       - name: Fetch dependencies
         run: |

--- a/src/passes.rs
+++ b/src/passes.rs
@@ -151,8 +151,8 @@ pub enum PassKind {
     GccrsRustcSucessNoCore,
     /// Compile the reference implementation of the Blake3 cryptographic algorithm
     Blake3,
-    /// Compile libcore from rust 1.49.0
-    LibCore149,
+    /// Compile the core library from various rust versions
+    LibCore,
 }
 
 #[derive(Debug)]
@@ -175,7 +175,7 @@ impl FromStr for PassKind {
             "gccrs-rustc-success-no-std" => Ok(PassKind::GccrsRustcSucessNoStd),
             "gccrs-rustc-success-no-core" => Ok(PassKind::GccrsRustcSucessNoCore),
             "blake3" => Ok(PassKind::Blake3),
-            "libcore-1.49" => Ok(PassKind::LibCore149),
+            "libcore" => Ok(PassKind::LibCore),
             s => Err(InvalidPassKind(s.to_string())),
         }
     }
@@ -190,7 +190,7 @@ impl Display for PassKind {
             PassKind::GccrsRustcSucessNoStd => "gccrs-rustc-success-no-std",
             PassKind::GccrsRustcSucessNoCore => "gccrs-rustc-success-no-core",
             PassKind::Blake3 => "blake3",
-            PassKind::LibCore149 => "libcore-1.49",
+            PassKind::LibCore => "libcore",
         };
 
         write!(f, "{}", s)

--- a/src/steps.rs
+++ b/src/steps.rs
@@ -1,0 +1,26 @@
+/// Various steps in the `gccrs` compilation pipeline
+pub enum CompileStep {
+    Expansion,
+    TypeCheck,
+    End,
+}
+
+impl CompileStep {
+    /// All the available compilation steps which `gccrs` can stop on
+    pub fn variants() -> [CompileStep; 3] {
+        [
+            CompileStep::Expansion,
+            CompileStep::TypeCheck,
+            CompileStep::End,
+        ]
+    }
+
+    /// Get the `gccrs` compile option associated with a compilation step
+    pub fn compile_option(&self) -> &str {
+        match self {
+            CompileStep::Expansion => "-frust-compile-until=expansion",
+            CompileStep::TypeCheck => "-frust-compile-until=typecheck",
+            CompileStep::End => "-frust-compile-until=end",
+        }
+    }
+}


### PR DESCRIPTION
Needs https://github.com/Rust-GCC/gccrs/pull/1527