### PR TITLE
nightly: Remove hack to find rust1 proper path

### DIFF
--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -25,7 +25,7 @@ jobs:
           cargo build --release
           git clone https://github.com/rust-gcc/gccrs --depth=1 local_gccrs
           git submodule update --init
-          target/release/testsuite-adaptor --gccrs rust1 --rustc rustc \
+          target/release/testsuite-adaptor --gccrs $(find /usr/local -name 'rust1') --rustc rustc \
               --output-dir output-dir-${{ matrix.testsuite }} \
               --yaml ${{ matrix.testsuite }}.yaml \
               --rust-path rust --gccrs-path local_gccrs \
@@ -35,9 +35,7 @@ jobs:
         run: |
           echo "{ \"name\": \"${{matrix.testsuite}}\", \"commit\": \"$(cat /GCCRS_BUILD)\", \"date\": \"$(date -I)\", \"results\": " >> ${{ matrix.testsuite }}.json
 
-          # FIXME: Hack: This allows us to access `rust1` directly.
-          # Figure out a better way to do it
-          PATH=/usr/local/libexec/gcc/x86_64-pc-linux-gnu/12.0.1/:$PATH ftf -f ${{ matrix.testsuite }}.yaml -j 1 --result-fmt "{ \"tests\": %t, \"passes\": %p, \"failures\": %f }" | tee log;
+          ftf -f ${{ matrix.testsuite }}.yaml -j 1 --result-fmt "{ \"tests\": %t, \"passes\": %p, \"failures\": %f }" | tee log;
 
           tail -n 1 log >> ${{ matrix.testsuite }}.json
           echo "}" >> ${{ matrix.testsuite }}.json


### PR DESCRIPTION
The hack relied on the fact that we were using gcc 12.0.1 as a base. A merge has been performed and this is no longer the case.

Closes #26 