### PR TITLE
compiler: Fix invalid rust1 default flags

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -24,7 +24,7 @@ impl Edition {
 /// All compiler kinds used in the testsuite
 #[derive(Clone, Copy)]
 pub enum Kind {
-    Gccrs,
+    Rust1,
     RustcBootstrap,
 }
 
@@ -38,7 +38,7 @@ impl Kind {
     /// Get the path associated with a specific compiler kind
     fn as_path_from_args(self, args: &Args) -> &Path {
         match self {
-            Kind::Gccrs => &args.gccrs,
+            Kind::Rust1 => &args.gccrs,
             Kind::RustcBootstrap => &args.rustc,
         }
     }
@@ -58,17 +58,14 @@ impl CommandExt for Command {
         match kind {
             // specify Rust language by default, which allows us to compile Rust files with funny extensions
             // use experimental flag
-            Kind::Gccrs => self
-                .arg("-frust-incomplete-and-experimental-compiler-do-not-use")
-                .arg("-x")
-                .arg("rust"),
+            Kind::Rust1 => self.arg("-frust-incomplete-and-experimental-compiler-do-not-use"),
             Kind::RustcBootstrap => self,
         }
     }
 
     fn default_env(&mut self, kind: Kind) -> &mut Command {
         match kind {
-            Kind::Gccrs => self,
+            Kind::Rust1 => self,
             Kind::RustcBootstrap => self.env("RUSTC_BOOTSTRAP", "1"),
         }
     }
@@ -101,7 +98,7 @@ impl Compiler {
     /// to `--crate-name` for `rustc` and `-frust-crate-name` for `gccrs`
     pub fn crate_name(mut self, crate_name: &str) -> Compiler {
         match self.kind() {
-            Kind::Gccrs => self.cmd.arg("-frust-crate-name"),
+            Kind::Rust1 => self.cmd.arg("-frust-crate-name"),
             Kind::RustcBootstrap => self.cmd.arg("--crate-name"),
         };
 
@@ -125,7 +122,7 @@ impl Compiler {
     /// `--edition` for `rustc` and `-frust-edition` for `gccrs`
     pub fn edition(mut self, edition: Edition) -> Compiler {
         match self.kind() {
-            Kind::Gccrs => self.cmd.arg("-frust-edition"),
+            Kind::Rust1 => self.cmd.arg("-frust-edition"),
             Kind::RustcBootstrap => self.cmd.arg("--edition"),
         };
 

--- a/src/passes/ast_export.rs
+++ b/src/passes/ast_export.rs
@@ -23,13 +23,13 @@ fn get_original_file_from_pretty(pretty_file: &Path) -> PathBuf {
 fn adapt_compilation(args: &Args, pretty_file: &Path) -> Result<TestCase, Error> {
     let original_file = get_original_file_from_pretty(pretty_file);
 
-    let is_valid = Compiler::new(Kind::Gccrs, args)
+    let is_valid = Compiler::new(Kind::Rust1, args)
         .command()
         .arg(original_file.as_os_str())
         .status()?
         .success();
 
-    let test_case = TestCase::from_compiler(Compiler::new(Kind::Gccrs, args))
+    let test_case = TestCase::from_compiler(Compiler::new(Kind::Rust1, args))
         .with_name(format!("Compile prettified `{}`", original_file.display()))
         .with_exit_code(if is_valid { 0 } else { 1 })
         .with_arg(pretty_file.display());
@@ -42,7 +42,7 @@ fn adapt_run(args: &Args, pretty_file: &Path) -> Result<TestCase, Error> {
     let binary_name = original_file.with_extension("");
 
     // Build the original binary
-    if !Compiler::new(Kind::Gccrs, args)
+    if !Compiler::new(Kind::Rust1, args)
         .command()
         .arg(original_file.as_os_str())
         .arg("-o")
@@ -72,7 +72,7 @@ fn adapt_run(args: &Args, pretty_file: &Path) -> Result<TestCase, Error> {
         Some(code) => {
             let binary_name = binary_name.with_extension("pretty");
             // We now build the "prettified binary". If that fails, skip it as that's been handled by the `Compile` phase
-            if !Compiler::new(Kind::Gccrs, args)
+            if !Compiler::new(Kind::Rust1, args)
                 .command()
                 .arg(pretty_file)
                 .arg("-o")
@@ -129,7 +129,7 @@ impl Pass for AstExport {
                 let new_path_original = output_dir.join(entry.path());
                 let new_path = output_dir.join(entry.path()).with_extension("pretty-rs");
 
-                Compiler::new(Kind::Gccrs, args)
+                Compiler::new(Kind::Rust1, args)
                     .command()
                     .arg(entry.path())
                     .arg("-frust-dump-ast-pretty")

--- a/src/passes/blake3.rs
+++ b/src/passes/blake3.rs
@@ -66,7 +66,7 @@ impl Pass for Blake3 {
         };
 
         let compiler = match self {
-            Blake3::GccrsOriginal | Blake3::GccrsPrelude => Compiler::new(Kind::Gccrs, args),
+            Blake3::GccrsOriginal | Blake3::GccrsPrelude => Compiler::new(Kind::Rust1, args),
             Blake3::RustcNoStd | Blake3::RustcNoCore => Compiler::new(Kind::RustcBootstrap, args),
         }
         .crate_type(CrateType::Library);

--- a/src/passes/gccrs_parsing.rs
+++ b/src/passes/gccrs_parsing.rs
@@ -28,7 +28,7 @@ impl Pass for GccrsParsing {
             .status()?
             .success();
 
-        let test_case = TestCase::from_compiler(Compiler::new(Kind::Gccrs, args))
+        let test_case = TestCase::from_compiler(Compiler::new(Kind::Rust1, args))
             .with_name(format!("Parse `{}`", file.display()))
             .with_exit_code(if is_valid { 0 } else { 1 })
             .with_timeout(1)

--- a/src/passes/gccrs_rustc_successes.rs
+++ b/src/passes/gccrs_rustc_successes.rs
@@ -86,7 +86,7 @@ impl Pass for GccrsRustcSuccesses {
             }
         }
 
-        let test_case = TestCase::from_compiler(Compiler::new(Kind::Gccrs, args))
+        let test_case = TestCase::from_compiler(Compiler::new(Kind::Rust1, args))
             .with_name(format!("Compile {} success `{}`", self, file.display()))
             .with_exit_code(0)
             // FIXME: Use proper duration here (#10)

--- a/src/passes/libcore.rs
+++ b/src/passes/libcore.rs
@@ -68,7 +68,7 @@ impl Pass for LibCore {
     }
 
     fn adapt(&self, args: &Args, file: &Path) -> Result<TestCase, Error> {
-        Ok(TestCase::from_compiler(Compiler::new(Kind::Gccrs, args))
+        Ok(TestCase::from_compiler(Compiler::new(Kind::Rust1, args))
             .with_name(format!(
                 "Compiling libcore {} ({} step)",
                 self.tag(),


### PR DESCRIPTION
The compiler API relied on `gccrs` being passed as a compiler, when in fact we pass `rust1` in the nightly testsuite that we run.

This should help tonight's testing run