### PR TITLE
ci: Do not use GitHub's checkout anymore

### DIFF
--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -18,10 +18,9 @@ jobs:
           # `result-fmt` feature
           cargo install --git https://github.com/cohenarthur/ftf
 
-      - uses: actions/checkout@v3
-
       - name: Generate testsuites (nightly)
         run: |
+          git clone https://github.com/rust-gcc/testing --depth 1 .
           cargo build --release
           git clone https://github.com/rust-gcc/gccrs --depth=1 local_gccrs
           git clone https://github.com/rust-lang/rust --branch 1.49.0 local_rust


### PR DESCRIPTION
This causes ownership issues when then cloning sub-repositories within the project. And we do not want submodules.
