### PR TITLE
Remove AST export run and fix AST export compile pass

### DIFF
--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -11,7 +11,7 @@ jobs:
     container: philberty/gccrs:latest
     strategy:
       matrix:
-        testsuite: [rustc-dejagnu, gccrs-parsing, gccrs-rustc-success, gccrs-rustc-success-no-std, gccrs-rustc-success-no-core, blake3, libcore]
+        testsuite: [rustc-dejagnu, gccrs-parsing, gccrs-rustc-success, gccrs-rustc-success-no-std, gccrs-rustc-success-no-core, blake3, libcore, ast-export]
         # testsuite: [blake3]
     steps:
       - name: Fetch dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ edition = "2021"
 name = "testsuite-adaptor"
 version = "0.1.0"
 [dependencies]
-anyhow = "1.0"
+anyhow = { version = "1.0", features = ["backtrace"] }
 colored = "2.0"
 rayon = "1.5"
 structopt = "0.3"

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -24,7 +24,7 @@ impl Edition {
 /// All compiler kinds used in the testsuite
 #[derive(Clone, Copy)]
 pub enum Kind {
-    Rust1,
+    Crab1,
     RustcBootstrap,
 }
 
@@ -38,7 +38,7 @@ impl Kind {
     /// Get the path associated with a specific compiler kind
     fn as_path_from_args(self, args: &Args) -> &Path {
         match self {
-            Kind::Rust1 => &args.gccrs,
+            Kind::Crab1 => &args.gccrs,
             Kind::RustcBootstrap => &args.rustc,
         }
     }
@@ -58,14 +58,14 @@ impl CommandExt for Command {
         match kind {
             // specify Rust language by default, which allows us to compile Rust files with funny extensions
             // use experimental flag
-            Kind::Rust1 => self.arg("-frust-incomplete-and-experimental-compiler-do-not-use"),
+            Kind::Crab1 => self.arg("-frust-incomplete-and-experimental-compiler-do-not-use"),
             Kind::RustcBootstrap => self,
         }
     }
 
     fn default_env(&mut self, kind: Kind) -> &mut Command {
         match kind {
-            Kind::Rust1 => self,
+            Kind::Crab1 => self,
             Kind::RustcBootstrap => self.env("RUSTC_BOOTSTRAP", "1"),
         }
     }
@@ -98,7 +98,7 @@ impl Compiler {
     /// to `--crate-name` for `rustc` and `-frust-crate-name` for `gccrs`
     pub fn crate_name(mut self, crate_name: &str) -> Compiler {
         match self.kind() {
-            Kind::Rust1 => self.cmd.arg("-frust-crate-name"),
+            Kind::Crab1 => self.cmd.arg("-frust-crate-name"),
             Kind::RustcBootstrap => self.cmd.arg("--crate-name"),
         };
 
@@ -122,7 +122,7 @@ impl Compiler {
     /// `--edition` for `rustc` and `-frust-edition` for `gccrs`
     pub fn edition(mut self, edition: Edition) -> Compiler {
         match self.kind() {
-            Kind::Rust1 => self.cmd.arg("-frust-edition"),
+            Kind::Crab1 => self.cmd.arg("-frust-edition"),
             Kind::RustcBootstrap => self.cmd.arg("--edition"),
         };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,7 +12,7 @@ pub enum MiscKind {
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("{0}")]
+    #[error("i/o error: {0}")]
     Io(std::io::Error),
     #[error("given path to `rust` does not exist: {0}")]
     NoRust(std::path::PathBuf),

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,10 +94,7 @@ fn pass_dispatch(pass: &PassKind) -> Vec<Box<dyn Pass>> {
         .into_iter()
         .flatten()
         .collect(),
-        PassKind::AstExport => vec![
-            Box::new(passes::AstExport::Compile),
-            Box::new(passes::AstExport::Run),
-        ],
+        PassKind::AstExport => vec![Box::new(passes::AstExport::Compile)],
     }
 }
 

--- a/src/passes/blake3.rs
+++ b/src/passes/blake3.rs
@@ -66,7 +66,7 @@ impl Pass for Blake3 {
         };
 
         let compiler = match self {
-            Blake3::GccrsOriginal | Blake3::GccrsPrelude => Compiler::new(Kind::Rust1, args),
+            Blake3::GccrsOriginal | Blake3::GccrsPrelude => Compiler::new(Kind::Crab1, args),
             Blake3::RustcNoStd | Blake3::RustcNoCore => Compiler::new(Kind::RustcBootstrap, args),
         }
         .crate_type(CrateType::Library);

--- a/src/passes/gccrs_parsing.rs
+++ b/src/passes/gccrs_parsing.rs
@@ -28,7 +28,7 @@ impl Pass for GccrsParsing {
             .status()?
             .success();
 
-        let test_case = TestCase::from_compiler(Compiler::new(Kind::Rust1, args))
+        let test_case = TestCase::from_compiler(Compiler::new(Kind::Crab1, args))
             .with_name(format!("Parse `{}`", file.display()))
             .with_exit_code(u8::from(!is_valid))
             .with_timeout(1)

--- a/src/passes/gccrs_rustc_successes.rs
+++ b/src/passes/gccrs_rustc_successes.rs
@@ -86,7 +86,7 @@ impl Pass for GccrsRustcSuccesses {
             }
         }
 
-        let test_case = TestCase::from_compiler(Compiler::new(Kind::Rust1, args))
+        let test_case = TestCase::from_compiler(Compiler::new(Kind::Crab1, args))
             .with_name(format!("Compile {} success `{}`", self, file.display()))
             .with_exit_code(0)
             // FIXME: Use proper duration here (#10)

--- a/src/passes/libcore.rs
+++ b/src/passes/libcore.rs
@@ -68,7 +68,7 @@ impl Pass for LibCore {
     }
 
     fn adapt(&self, args: &Args, file: &Path) -> Result<TestCase, Error> {
-        Ok(TestCase::from_compiler(Compiler::new(Kind::Rust1, args))
+        Ok(TestCase::from_compiler(Compiler::new(Kind::Crab1, args))
             .with_name(format!(
                 "Compiling libcore {} ({} step)",
                 self.tag(),


### PR DESCRIPTION
- anyhow: Use `backtrace` feature
- ci: Add `ast-export` back to the nightly runs
- ast-export: Remove `AstExport::Run` pass
- misc: Rename `Compiler::Rust1` to `Compiler::Crab1`
